### PR TITLE
github-issue-14

### DIFF
--- a/src/arxiv_agent/history/__init__.py
+++ b/src/arxiv_agent/history/__init__.py
@@ -1,0 +1,4 @@
+"""Paper history management module."""
+from arxiv_agent.history.paper_history import PaperHistory
+
+__all__ = ["PaperHistory"]

--- a/src/arxiv_agent/history/paper_history.py
+++ b/src/arxiv_agent/history/paper_history.py
@@ -1,0 +1,95 @@
+"""Paper history management for tracking processed papers."""
+import json
+import logging
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+
+class PaperHistory:
+    """
+    Manages history of processed papers.
+
+    Stores processed paper IDs in a JSON file to prevent duplicate processing.
+    Handles file I/O errors gracefully to ensure application continues even if
+    history management fails.
+    """
+
+    def __init__(self, history_file: str) -> None:
+        """
+        Initialize paper history manager.
+
+        Args:
+            history_file: Path to the JSON file storing processed paper IDs.
+        """
+        self._history_file = Path(history_file)
+        self._processed_ids: set[str] = self._load_history()
+
+    def _load_history(self) -> set[str]:
+        """
+        Load processed paper IDs from file.
+
+        Returns:
+            Set of processed paper IDs. Empty set if file doesn't exist or
+            cannot be read.
+        """
+        if not self._history_file.exists():
+            logger.info(f"History file not found: {self._history_file}. Starting with empty history.")
+            return set()
+
+        try:
+            with self._history_file.open("r", encoding="utf-8") as f:
+                data = json.load(f)
+                processed_papers = data.get("processed_papers", [])
+                if not isinstance(processed_papers, list):
+                    logger.warning("Invalid history format: 'processed_papers' is not a list. Starting with empty history.")
+                    return set()
+                logger.info(f"Loaded {len(processed_papers)} processed paper IDs from history.")
+                return set(processed_papers)
+        except json.JSONDecodeError as e:
+            logger.warning(f"Failed to parse history file: {e}. Starting with empty history.")
+            return set()
+        except OSError as e:
+            logger.error(f"Failed to read history file: {e}. Starting with empty history.")
+            return set()
+
+    def is_processed(self, paper_id: str) -> bool:
+        """
+        Check if a paper has been processed.
+
+        Args:
+            paper_id: arXiv paper ID to check.
+
+        Returns:
+            True if paper has been processed, False otherwise.
+        """
+        return paper_id in self._processed_ids
+
+    def mark_processed(self, paper_ids: list[str]) -> None:
+        """
+        Mark papers as processed and save to file.
+
+        Args:
+            paper_ids: List of arXiv paper IDs to mark as processed.
+        """
+        if not paper_ids:
+            return
+
+        self._processed_ids.update(paper_ids)
+        self._save_history()
+
+    def _save_history(self) -> None:
+        """
+        Save processed paper IDs to file.
+
+        Logs error if save fails but does not raise exception to prevent
+        disrupting main application flow.
+        """
+        try:
+            self._history_file.parent.mkdir(parents=True, exist_ok=True)
+            with self._history_file.open("w", encoding="utf-8") as f:
+                data = {"processed_papers": sorted(self._processed_ids)}
+                json.dump(data, f, indent=2, ensure_ascii=False)
+            logger.info(f"Saved {len(self._processed_ids)} processed paper IDs to history.")
+        except OSError as e:
+            logger.error(f"Failed to save history file: {e}")

--- a/tests/test_arxiv_agent_main.py
+++ b/tests/test_arxiv_agent_main.py
@@ -1,0 +1,329 @@
+"""Integration tests for arxiv agent main flow."""
+import json
+from pathlib import Path
+from datetime import datetime
+
+import pytest
+
+from arxiv_agent.collection.models import Paper
+from arxiv_agent.summarization.models import Summary
+from arxiv_agent.main import main
+
+
+class TestArxivAgentMain:
+    """Integration tests for main() function with history management."""
+
+    def test_all_papers_are_new(
+        self, tmp_path: pytest.fixture, mocker: pytest.fixture
+    ) -> None:
+        """Should process and save all papers when all are new."""
+        # Setup
+        config_file = tmp_path / "config.yaml"
+        history_file = tmp_path / "history.json"
+        config_file.write_text(
+            f"""
+arxiv:
+  max_results: 10
+  categories: ["cs.AI"]
+  keywords: ["LLM"]
+gemini:
+  model: gemini-1.5-pro
+  prompt_template: "Title: {{title}}, Authors: {{authors}}, Abstract: {{abstract}}"
+  temperature: 0.7
+  max_tokens: 1000
+notification:
+  slack:
+    webhook_url: "https://hooks.slack.com/services/test"
+history_file: "{history_file}"
+""",
+            encoding="utf-8",
+        )
+
+        papers = [
+            Paper(
+                arxiv_id="2301.00001v1",
+                title="Paper 1",
+                authors=["Author A"],
+                abstract="Abstract 1",
+                published=datetime(2023, 1, 1),
+                categories=["cs.AI"],
+                pdf_url="https://arxiv.org/pdf/2301.00001v1.pdf",
+            ),
+            Paper(
+                arxiv_id="2301.00002v1",
+                title="Paper 2",
+                authors=["Author B"],
+                abstract="Abstract 2",
+                published=datetime(2023, 1, 2),
+                categories=["cs.AI"],
+                pdf_url="https://arxiv.org/pdf/2301.00002v1.pdf",
+            ),
+        ]
+        summaries = [
+            Summary(paper_id="2301.00001v1", title="Paper 1", summary_text="Summary 1"),
+            Summary(paper_id="2301.00002v1", title="Paper 2", summary_text="Summary 2"),
+        ]
+
+        mocker.patch("sys.argv", ["main.py", str(config_file)])
+        mocker.patch.dict("os.environ", {"GEMINI_API_KEY": "test-key"})
+        mocker.patch(
+            "arxiv_agent.main.ArxivClient.search_papers", return_value=papers
+        )
+        mock_summarize = mocker.patch(
+            "arxiv_agent.main.GeminiClient.summarize", side_effect=summaries
+        )
+        mocker.patch("arxiv_agent.main.Notifier.send_all")
+
+        # Execute
+        exit_code = main()
+
+        # Verify
+        assert exit_code == 0
+        assert mock_summarize.call_count == 2
+
+        history_data = json.loads(history_file.read_text(encoding="utf-8"))
+        assert set(history_data["processed_papers"]) == {
+            "2301.00001v1",
+            "2301.00002v1",
+        }
+
+    def test_all_papers_are_processed(
+        self, tmp_path: pytest.fixture, mocker: pytest.fixture
+    ) -> None:
+        """Should skip all papers when all are already processed."""
+        # Setup
+        config_file = tmp_path / "config.yaml"
+        history_file = tmp_path / "history.json"
+        config_file.write_text(
+            f"""
+arxiv:
+  max_results: 10
+  categories: ["cs.AI"]
+  keywords: ["LLM"]
+gemini:
+  model: gemini-1.5-pro
+  prompt_template: "Title: {{title}}, Authors: {{authors}}, Abstract: {{abstract}}"
+  temperature: 0.7
+  max_tokens: 1000
+notification:
+  slack:
+    webhook_url: "https://hooks.slack.com/services/test"
+history_file: "{history_file}"
+""",
+            encoding="utf-8",
+        )
+        history_file.write_text(
+            json.dumps({"processed_papers": ["2301.00001v1", "2301.00002v1"]}),
+            encoding="utf-8",
+        )
+
+        papers = [
+            Paper(
+                arxiv_id="2301.00001v1",
+                title="Paper 1",
+                authors=["Author A"],
+                abstract="Abstract 1",
+                published=datetime(2023, 1, 1),
+                categories=["cs.AI"],
+                pdf_url="https://arxiv.org/pdf/2301.00001v1.pdf",
+            ),
+            Paper(
+                arxiv_id="2301.00002v1",
+                title="Paper 2",
+                authors=["Author B"],
+                abstract="Abstract 2",
+                published=datetime(2023, 1, 2),
+                categories=["cs.AI"],
+                pdf_url="https://arxiv.org/pdf/2301.00002v1.pdf",
+            ),
+        ]
+
+        mocker.patch("sys.argv", ["main.py", str(config_file)])
+        mocker.patch.dict("os.environ", {"GEMINI_API_KEY": "test-key"})
+        mocker.patch(
+            "arxiv_agent.main.ArxivClient.search_papers", return_value=papers
+        )
+        mock_summarize = mocker.patch("arxiv_agent.main.GeminiClient.summarize")
+        mocker.patch("arxiv_agent.main.Notifier.send_all")
+
+        # Execute
+        exit_code = main()
+
+        # Verify
+        assert exit_code == 0
+        mock_summarize.assert_not_called()
+
+        history_data = json.loads(history_file.read_text(encoding="utf-8"))
+        assert set(history_data["processed_papers"]) == {
+            "2301.00001v1",
+            "2301.00002v1",
+        }
+
+    def test_mixed_new_and_processed_papers(
+        self, tmp_path: pytest.fixture, mocker: pytest.fixture
+    ) -> None:
+        """Should process only new papers when mixed."""
+        # Setup
+        config_file = tmp_path / "config.yaml"
+        history_file = tmp_path / "history.json"
+        config_file.write_text(
+            f"""
+arxiv:
+  max_results: 10
+  categories: ["cs.AI"]
+  keywords: ["LLM"]
+gemini:
+  model: gemini-1.5-pro
+  prompt_template: "Title: {{title}}, Authors: {{authors}}, Abstract: {{abstract}}"
+  temperature: 0.7
+  max_tokens: 1000
+notification:
+  slack:
+    webhook_url: "https://hooks.slack.com/services/test"
+history_file: "{history_file}"
+""",
+            encoding="utf-8",
+        )
+        history_file.write_text(
+            json.dumps({"processed_papers": ["2301.00001v1"]}),
+            encoding="utf-8",
+        )
+
+        papers = [
+            Paper(
+                arxiv_id="2301.00001v1",
+                title="Paper 1",
+                authors=["Author A"],
+                abstract="Abstract 1",
+                published=datetime(2023, 1, 1),
+                categories=["cs.AI"],
+                pdf_url="https://arxiv.org/pdf/2301.00001v1.pdf",
+            ),
+            Paper(
+                arxiv_id="2301.00002v1",
+                title="Paper 2",
+                authors=["Author B"],
+                abstract="Abstract 2",
+                published=datetime(2023, 1, 2),
+                categories=["cs.AI"],
+                pdf_url="https://arxiv.org/pdf/2301.00002v1.pdf",
+            ),
+        ]
+        summaries = [
+            Summary(paper_id="2301.00002v1", title="Paper 2", summary_text="Summary 2"),
+        ]
+
+        mocker.patch("sys.argv", ["main.py", str(config_file)])
+        mocker.patch.dict("os.environ", {"GEMINI_API_KEY": "test-key"})
+        mocker.patch(
+            "arxiv_agent.main.ArxivClient.search_papers", return_value=papers
+        )
+        mock_summarize = mocker.patch(
+            "arxiv_agent.main.GeminiClient.summarize", side_effect=summaries
+        )
+        mocker.patch("arxiv_agent.main.Notifier.send_all")
+
+        # Execute
+        exit_code = main()
+
+        # Verify
+        assert exit_code == 0
+        assert mock_summarize.call_count == 1
+
+        history_data = json.loads(history_file.read_text(encoding="utf-8"))
+        assert set(history_data["processed_papers"]) == {
+            "2301.00001v1",
+            "2301.00002v1",
+        }
+
+    def test_partial_summarization_failure(
+        self, tmp_path: pytest.fixture, mocker: pytest.fixture
+    ) -> None:
+        """Should save only successfully summarized papers to history."""
+        # Setup
+        config_file = tmp_path / "config.yaml"
+        history_file = tmp_path / "history.json"
+        config_file.write_text(
+            f"""
+arxiv:
+  max_results: 10
+  categories: ["cs.AI"]
+  keywords: ["LLM"]
+gemini:
+  model: gemini-1.5-pro
+  prompt_template: "Title: {{title}}, Authors: {{authors}}, Abstract: {{abstract}}"
+  temperature: 0.7
+  max_tokens: 1000
+notification:
+  slack:
+    webhook_url: "https://hooks.slack.com/services/test"
+history_file: "{history_file}"
+""",
+            encoding="utf-8",
+        )
+
+        papers = [
+            Paper(
+                arxiv_id="2301.00001v1",
+                title="Paper 1",
+                authors=["Author A"],
+                abstract="Abstract 1",
+                published=datetime(2023, 1, 1),
+                categories=["cs.AI"],
+                pdf_url="https://arxiv.org/pdf/2301.00001v1.pdf",
+            ),
+            Paper(
+                arxiv_id="2301.00002v1",
+                title="Paper 2",
+                authors=["Author B"],
+                abstract="Abstract 2",
+                published=datetime(2023, 1, 2),
+                categories=["cs.AI"],
+                pdf_url="https://arxiv.org/pdf/2301.00002v1.pdf",
+            ),
+            Paper(
+                arxiv_id="2301.00003v1",
+                title="Paper 3",
+                authors=["Author C"],
+                abstract="Abstract 3",
+                published=datetime(2023, 1, 3),
+                categories=["cs.AI"],
+                pdf_url="https://arxiv.org/pdf/2301.00003v1.pdf",
+            ),
+        ]
+
+        # Mock: Paper 1 succeeds, Paper 2 fails, Paper 3 succeeds
+        def mock_summarize_side_effect(paper: Paper) -> Summary:
+            if paper.arxiv_id == "2301.00002v1":
+                raise Exception("API rate limit exceeded")
+            return Summary(
+                paper_id=paper.arxiv_id,
+                title=paper.title,
+                summary_text=f"Summary for {paper.title}",
+            )
+
+        mocker.patch("sys.argv", ["main.py", str(config_file)])
+        mocker.patch.dict("os.environ", {"GEMINI_API_KEY": "test-key"})
+        mocker.patch(
+            "arxiv_agent.main.ArxivClient.search_papers", return_value=papers
+        )
+        mock_summarize = mocker.patch(
+            "arxiv_agent.main.GeminiClient.summarize",
+            side_effect=mock_summarize_side_effect,
+        )
+        mocker.patch("arxiv_agent.main.Notifier.send_all")
+
+        # Execute
+        exit_code = main()
+
+        # Verify
+        assert exit_code == 0
+        assert mock_summarize.call_count == 3
+
+        # Only successfully summarized papers should be in history
+        history_data = json.loads(history_file.read_text(encoding="utf-8"))
+        assert set(history_data["processed_papers"]) == {
+            "2301.00001v1",
+            "2301.00003v1",
+        }
+        assert "2301.00002v1" not in history_data["processed_papers"]

--- a/tests/test_paper_history.py
+++ b/tests/test_paper_history.py
@@ -1,0 +1,182 @@
+"""Tests for paper history management."""
+import json
+from pathlib import Path
+
+import pytest
+
+from arxiv_agent.history import PaperHistory
+
+
+class TestPaperHistory:
+    """Test cases for PaperHistory class."""
+
+    def test_init_with_nonexistent_file(self, tmp_path: Path) -> None:
+        """Test initialization with non-existent history file."""
+        history_file = tmp_path / "history.json"
+        history = PaperHistory(str(history_file))
+
+        assert not history.is_processed("2301.12345v1")
+
+    def test_init_with_existing_file(self, tmp_path: Path) -> None:
+        """Test initialization with existing history file."""
+        history_file = tmp_path / "history.json"
+        history_file.write_text(
+            json.dumps({"processed_papers": ["2301.12345v1", "2301.67890v2"]}),
+            encoding="utf-8",
+        )
+
+        history = PaperHistory(str(history_file))
+
+        assert history.is_processed("2301.12345v1")
+        assert history.is_processed("2301.67890v2")
+        assert not history.is_processed("2301.99999v1")
+
+    def test_init_with_corrupted_file(self, tmp_path: Path) -> None:
+        """Test initialization with corrupted JSON file."""
+        history_file = tmp_path / "history.json"
+        history_file.write_text("{ invalid json", encoding="utf-8")
+
+        history = PaperHistory(str(history_file))
+
+        assert not history.is_processed("2301.12345v1")
+
+    def test_init_with_invalid_format(self, tmp_path: Path) -> None:
+        """Test initialization with invalid data format."""
+        history_file = tmp_path / "history.json"
+        history_file.write_text(
+            json.dumps({"processed_papers": "not_a_list"}),
+            encoding="utf-8",
+        )
+
+        history = PaperHistory(str(history_file))
+
+        assert not history.is_processed("2301.12345v1")
+
+    def test_init_with_missing_key(self, tmp_path: Path) -> None:
+        """Test initialization with missing 'processed_papers' key."""
+        history_file = tmp_path / "history.json"
+        history_file.write_text(json.dumps({"other_key": []}), encoding="utf-8")
+
+        history = PaperHistory(str(history_file))
+
+        assert not history.is_processed("2301.12345v1")
+
+    def test_is_processed_returns_false_for_new_paper(self, tmp_path: Path) -> None:
+        """Test is_processed returns False for new paper."""
+        history_file = tmp_path / "history.json"
+        history = PaperHistory(str(history_file))
+
+        assert not history.is_processed("2301.12345v1")
+
+    def test_is_processed_returns_true_for_existing_paper(self, tmp_path: Path) -> None:
+        """Test is_processed returns True for existing paper."""
+        history_file = tmp_path / "history.json"
+        history_file.write_text(
+            json.dumps({"processed_papers": ["2301.12345v1"]}),
+            encoding="utf-8",
+        )
+        history = PaperHistory(str(history_file))
+
+        assert history.is_processed("2301.12345v1")
+
+    def test_mark_processed_saves_single_paper(self, tmp_path: Path) -> None:
+        """Test marking a single paper as processed."""
+        history_file = tmp_path / "history.json"
+        history = PaperHistory(str(history_file))
+
+        history.mark_processed(["2301.12345v1"])
+
+        assert history.is_processed("2301.12345v1")
+        assert history_file.exists()
+
+        saved_data = json.loads(history_file.read_text(encoding="utf-8"))
+        assert saved_data == {"processed_papers": ["2301.12345v1"]}
+
+    def test_mark_processed_saves_multiple_papers(self, tmp_path: Path) -> None:
+        """Test marking multiple papers as processed."""
+        history_file = tmp_path / "history.json"
+        history = PaperHistory(str(history_file))
+
+        history.mark_processed(["2301.12345v1", "2301.67890v2"])
+
+        assert history.is_processed("2301.12345v1")
+        assert history.is_processed("2301.67890v2")
+
+        saved_data = json.loads(history_file.read_text(encoding="utf-8"))
+        assert set(saved_data["processed_papers"]) == {"2301.12345v1", "2301.67890v2"}
+
+    def test_mark_processed_with_empty_list(self, tmp_path: Path) -> None:
+        """Test marking empty list does not create file."""
+        history_file = tmp_path / "history.json"
+        history = PaperHistory(str(history_file))
+
+        history.mark_processed([])
+
+        assert not history_file.exists()
+
+    def test_mark_processed_merges_with_existing(self, tmp_path: Path) -> None:
+        """Test marking processed merges with existing history."""
+        history_file = tmp_path / "history.json"
+        history_file.write_text(
+            json.dumps({"processed_papers": ["2301.12345v1"]}),
+            encoding="utf-8",
+        )
+        history = PaperHistory(str(history_file))
+
+        history.mark_processed(["2301.67890v2", "2301.99999v3"])
+
+        assert history.is_processed("2301.12345v1")
+        assert history.is_processed("2301.67890v2")
+        assert history.is_processed("2301.99999v3")
+
+        saved_data = json.loads(history_file.read_text(encoding="utf-8"))
+        assert set(saved_data["processed_papers"]) == {
+            "2301.12345v1",
+            "2301.67890v2",
+            "2301.99999v3",
+        }
+
+    def test_mark_processed_deduplicates_papers(self, tmp_path: Path) -> None:
+        """Test marking same paper multiple times doesn't create duplicates."""
+        history_file = tmp_path / "history.json"
+        history = PaperHistory(str(history_file))
+
+        history.mark_processed(["2301.12345v1"])
+        history.mark_processed(["2301.12345v1", "2301.67890v2"])
+
+        saved_data = json.loads(history_file.read_text(encoding="utf-8"))
+        assert set(saved_data["processed_papers"]) == {"2301.12345v1", "2301.67890v2"}
+
+    def test_persistence_across_instances(self, tmp_path: Path) -> None:
+        """Test history persists across multiple instances."""
+        history_file = tmp_path / "history.json"
+
+        history1 = PaperHistory(str(history_file))
+        history1.mark_processed(["2301.12345v1"])
+
+        history2 = PaperHistory(str(history_file))
+        assert history2.is_processed("2301.12345v1")
+
+    def test_file_saved_in_sorted_order(self, tmp_path: Path) -> None:
+        """Test saved file has papers in sorted order."""
+        history_file = tmp_path / "history.json"
+        history = PaperHistory(str(history_file))
+
+        history.mark_processed(["2301.99999v1", "2301.12345v1", "2301.67890v2"])
+
+        saved_data = json.loads(history_file.read_text(encoding="utf-8"))
+        assert saved_data["processed_papers"] == [
+            "2301.12345v1",
+            "2301.67890v2",
+            "2301.99999v1",
+        ]
+
+    def test_creates_parent_directory_if_missing(self, tmp_path: Path) -> None:
+        """Test creates parent directory when saving."""
+        history_file = tmp_path / "subdir" / "history.json"
+        history = PaperHistory(str(history_file))
+
+        history.mark_processed(["2301.12345v1"])
+
+        assert history_file.exists()
+        assert history_file.parent.is_dir()


### PR DESCRIPTION
## Summary

## 問題

現在、アプリケーションを複数回実行すると、同じ論文が繰り返し要約・通知されてしまう。

## 現在の動作

1. arXiv APIから論文を検索
2. 全ての論文を要約
3. 通知を送信

このフローでは、既に要約済みの論文を判別する仕組みがないため、実行の度に同じ論文が処理される。

## 期待される動作

- 一度要約した論文は、次回実行時には除外される
- 新しい論文のみが要約・通知される
- ユーザーが既に読んだ論文の重複通知を避けられる

## 実装案

以下のような実装を検討できる：

1. **論文履歴の永続化**
   - 要約済みの論文IDをファイル（JSON/SQLiteなど）に保存
   - 例：`processed_papers.json` に arXiv ID のリストを保存

2. **重複チェック機能**
   - 検索結果から既に処理済みの論文をフィルタリング
   - `src/arxiv_agent/main.py` で履歴チェックを追加

3. **履歴管理モジュール**
   - 新規モジュール `src/arxiv_agent/history/` を作成
   - `PaperHistory` クラスで履歴の読み書きを管理

## 技術的考慮事項

- ファイルベース vs データベース（初期実装ではJSONファイルでシンプルに）
- 履歴の保存場所（プロジェクトルート or 設定可能なパス）
- 履歴のクリア機能の必要性
- エラーハンドリング（ファイル読み書きの失敗時）

## 関連ファイル

- `src/arxiv_agent/main.py`: メインフロー（履歴チェックを追加）
- `src/arxiv_agent/collection/models.py`: Paper モデル（arXiv ID を使用）

## Execution Report

Piece `backend` completed successfully.

Closes #14

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added persistent paper tracking to maintain a history of processed papers, preventing duplicate processing across application runs

<!-- end of auto-generated comment: release notes by coderabbit.ai -->