### PR TITLE
github-issue-10-add-software-architecture-and-code-quality-keywords-to-pape-1

### DIFF
--- a/config/default.yaml
+++ b/config/default.yaml
@@ -3,12 +3,39 @@ arxiv:
     - cs.AI
     - cs.LG
     - cs.CL
+    - cs.SE
   keywords:
+    # LLM関連
     - LLM
     - Large Language Model
     - GPT
     - Transformer
-  max_results: 5
+    # ソフトウェアアーキテクチャ
+    - Software Architecture
+    - Microservices
+    - Design Patterns
+    - Clean Architecture
+    - Domain-Driven Design
+    - DDD
+    - Hexagonal Architecture
+    # コード品質・リファクタリング
+    - Code Quality
+    - Clean Code
+    - Refactoring
+    - Technical Debt
+    - Code Smell
+    - Encapsulation
+    - SOLID
+    - Coupling
+    - Cohesion
+    # テスト・開発手法
+    - Test-Driven Development
+    - TDD
+    - Behavior-Driven Development
+    - BDD
+    - Unit Testing
+    - Integration Testing
+  max_results: 10
 
 gemini:
   model: gemini-pro

--- a/tests/test_arxiv_client.py
+++ b/tests/test_arxiv_client.py
@@ -45,3 +45,21 @@ class TestArxivClient:
         client = ArxivClient(max_results=10)
         with pytest.raises(ValueError, match="keywords must not be empty"):
             client.search_papers(['cs.AI'], [])
+
+    def test_build_query_with_expanded_categories_and_keywords(self):
+        """Should build query correctly with expanded categories and keywords."""
+        client = ArxivClient(max_results=10)
+        categories = ['cs.AI', 'cs.LG', 'cs.CL', 'cs.SE']
+        keywords = [
+            'LLM', 'Software Architecture', 'Clean Code',
+            'Test-Driven Development', 'Domain-Driven Design'
+        ]
+        query = client._build_query(categories, keywords)
+
+        assert '(cat:cs.AI OR cat:cs.LG OR cat:cs.CL OR cat:cs.SE)' in query
+        assert 'all:"LLM"' in query
+        assert 'all:"Software Architecture"' in query
+        assert 'all:"Clean Code"' in query
+        assert 'all:"Test-Driven Development"' in query
+        assert 'all:"Domain-Driven Design"' in query
+        assert query.count(' OR ') == 7  # 3 for categories + 4 for keywords

--- a/tests/test_config_loader.py
+++ b/tests/test_config_loader.py
@@ -187,3 +187,24 @@ notification:
 
         with pytest.raises(ValueError, match="gemini.prompt_template must be a non-empty string"):
             load_config(str(config_file))
+
+    def test_load_default_config(self):
+        """Should successfully load the default configuration file."""
+        default_config_path = Path(__file__).parent.parent / "config" / "default.yaml"
+
+        config = load_config(str(default_config_path))
+
+        assert isinstance(config, Config)
+        assert "cs.AI" in config.arxiv.categories
+        assert "cs.LG" in config.arxiv.categories
+        assert "cs.CL" in config.arxiv.categories
+        assert "cs.SE" in config.arxiv.categories
+        assert len(config.arxiv.categories) == 4
+
+        assert "LLM" in config.arxiv.keywords
+        assert "Software Architecture" in config.arxiv.keywords
+        assert "Clean Code" in config.arxiv.keywords
+        assert "Test-Driven Development" in config.arxiv.keywords
+        assert len(config.arxiv.keywords) == 26
+
+        assert config.arxiv.max_results == 10


### PR DESCRIPTION
## Summary

## 概要

現在の論文収集対象をLLM分野だけでなく、**ソフトウェアアーキテクチャ**や**コード品質**分野にも拡張する。

## 現在の設定

`config/default.yaml` (1-11行目):
```yaml
arxiv:
  categories:
    - cs.AI
    - cs.LG
    - cs.CL
  keywords:
    - LLM
    - Large Language Model
    - GPT
    - Transformer
  max_results: 5
```

**現在の対象分野：**
- AI/機械学習/自然言語処理のみ

## 追加すべきカテゴリ

```yaml
categories:
  # 既存
  - cs.AI  # Artificial Intelligence
  - cs.LG  # Machine Learning
  - cs.CL  # Computation and Language
  # 追加
  - cs.SE  # Software Engineering
```

## 追加すべきキーワード

### ソフトウェアアーキテクチャ
- Software Architecture
- Microservices
- Design Patterns
- Clean Architecture
- Domain-Driven Design
- DDD
- Hexagonal Architecture

### コード品質・リファクタリング
- Code Quality
- Clean Code
- Refactoring
- Technical Debt
- Code Smell
- Encapsulation
- SOLID
- Coupling
- Cohesion

### テスト・開発手法
- Test-Driven Development
- TDD
- Behavior-Driven Development
- BDD
- Unit Testing
- Integration Testing

## 期待される効果

- LLM以外のソフトウェアエンジニアリング分野の最新研究も把握できる
- コード品質向上に関する学術的知見が得られる
- アーキテクチャ設計の参考になる論文を自動収集できる

## 修正対象

- `config/default.yaml`のcategoriesとkeywordsセクション
- （必要に応じて）max_resultsの調整（対象が増えるため）

## 注意点

キーワードを増やしすぎると：
- 論文数が大量になり要約コストが増加
- 通知が多すぎて逆に読まれなくなる可能性

段階的に追加し、適切なmax_resultsを設定する必要がある。

## Execution Report

Piece `default` completed successfully.

Closes #10

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Software Engineering category to arxiv searches
  * Expanded arxiv search keywords to cover broader software topics including architecture, code quality, and testing
  * Increased default search results from 5 to 10
  * Added AI model configuration options for temperature, token limits, and prompt customization

<!-- end of auto-generated comment: release notes by coderabbit.ai -->